### PR TITLE
Always Use Configured Currency For Default Values

### DIFF
--- a/app/models/workarea/payment/gift_card.rb
+++ b/app/models/workarea/payment/gift_card.rb
@@ -16,9 +16,9 @@ module Workarea
       # by a customer purchasing it.
       field :order_id, type: String
 
-      field :amount, type: Money, default: 0.to_m
-      field :used, type: Money, default: 0.to_m
-      field :balance, type: Money, default: 0.to_m
+      field :amount, type: Money, default: 0
+      field :used, type: Money, default: 0
+      field :balance, type: Money, default: 0
 
       has_many :redemptions, class_name: 'Workarea::Payment::GiftCard::Redemption'
 

--- a/test/models/workarea/payment/gift_card_test.rb
+++ b/test/models/workarea/payment/gift_card_test.rb
@@ -4,7 +4,7 @@ module Workarea
   class Payment
     class GiftCardTest < TestCase
       def test_currency
-        @_existing_currency = Money.default_currency
+        existing_currency = Money.default_currency
         usd = Money::Currency.new('USD')
         aud = Money::Currency.new('AUD')
 
@@ -18,7 +18,7 @@ module Workarea
 
         assert_equal(aud, card.used.currency)
       ensure
-        Money.default_currency = @_existing_currency
+        Money.default_currency = existing_currency
       end
 
       def test_not_expired

--- a/test/models/workarea/payment/gift_card_test.rb
+++ b/test/models/workarea/payment/gift_card_test.rb
@@ -3,6 +3,24 @@ require 'test_helper'
 module Workarea
   class Payment
     class GiftCardTest < TestCase
+      def test_currency
+        @_existing_currency = Money.default_currency
+        usd = Money::Currency.new('USD')
+        aud = Money::Currency.new('AUD')
+
+        card = GiftCard.create!(amount: 10.to_m)
+        Money.default_currency = usd
+
+        assert_equal(usd, card.used.currency)
+
+        Money.default_currency = aud
+        card = GiftCard.create!(amount: 10.to_m)
+
+        assert_equal(aud, card.used.currency)
+      ensure
+        Money.default_currency = @_existing_currency
+      end
+
       def test_not_expired
         expired     = Workarea::Payment::GiftCard.create!(amount: 10.to_m, expires_at: Time.now - 1.day)
         not_expired = Workarea::Payment::GiftCard.create!(amount: 10.to_m, expires_at: Time.now + 1.day)


### PR DESCRIPTION
When specifying a `default:` for a Mongoid `Money` field, the value must
be wrapped in a lambda in order to preserve the currency configuration
specified by the application at runtime.