### PR TITLE
Fix Tests for 2020

### DIFF
--- a/test/integration/workarea/storefront/checkout_gift_cards_integration_test.rb
+++ b/test/integration/workarea/storefront/checkout_gift_cards_integration_test.rb
@@ -94,7 +94,7 @@ module Workarea
                 credit_card: {
                   number: '1',
                   month:  1,
-                  year:   2020,
+                  year:   next_year,
                   cvv:    '999'
                 }
               }


### PR DESCRIPTION
Update all tests so that they no longer depend on the year 2020 as an
expiration year. Instead, use the  method provided by Workarea.

GIFTCARDS-6