### PR TITLE
Fix misconfiguration

### DIFF
--- a/config/initializers/configuration.rb
+++ b/config/initializers/configuration.rb
@@ -3,7 +3,7 @@ Workarea.configure do |config|
   config.customization_types << 'Workarea::Catalog::Customizations::GiftCard'
   config.fulfillment_policies << 'Workarea::Fulfillment::Policies::CreateGiftCard'
   config.checkout_steps << 'Workarea::Checkout::Steps::GiftCard'
-  config.tender_types.prepend(:gift_cards)
+  config.tender_types.prepend(:gift_card)
   config.seeds << 'Workarea::GiftCardSeeds'
   config.jump_to_navigation.merge!('Gift Cards' => :payment_gift_cards_path)
 


### PR DESCRIPTION
This causes it to not assign a valid tender to a transaction.