### PR TITLE
Improve Test Experience For Custom Gift Card Gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,30 @@ end
 
 Note that it is set to a string of the class constant, and not an instance of the class. The system constantizes and initializes a new instance whenever it uses the gateway to ensure autoloading works correctly and so a gateway that cares about the current state of the application is applied correctly. This is most relevant in multi-site environments where each site might want to use their own gift card gateway.
 
+### Testing Your Custom Gateway
+
+Workarea comes with unit tests for the main Gateway class, and you can
+decorate this test to provide your own setup code. A minimal
+implementation would look as follows:
+
+```ruby
+module Workarea
+  module GiftCards
+    decorate GatewayTest do
+      # Provide your own Gateway instance here to use it in each test.
+      def gateway
+        CustomGiftCardGateway.new
+      end
+
+      # Provide a custom object representing a Gift Card on your
+      # 3rd-party service.
+      def gift_card
+        CustomGiftCard.new(balance: 10.to_m)
+      end
+    end
+  end
+end
+```
 
 Workarea Commerce Documentation
 --------------------------------------------------------------------------------

--- a/test/lib/workarea/gift_cards/gateway_test.rb
+++ b/test/lib/workarea/gift_cards/gateway_test.rb
@@ -5,10 +5,17 @@ module Workarea
     class GatewayTest < TestCase
       setup :gift_card
 
+      # Override this to instantiate an object that models a gift card
+      # on the remote system.
       def gift_card
         @gift_card ||= create_gift_card(amount: 10.to_m)
       end
 
+      # The tender object used on an order that will be passed into each
+      # gateway method call. Override this to provide your own
+      # information.
+      #
+      # @return [Payment::Tender::GiftCard]
       def tender
         @tender ||= Payment::Tender::GiftCard.new(
           number: gift_card.token,
@@ -16,81 +23,108 @@ module Workarea
         )
       end
 
+      # Override this in your test to instantiate a gateway for use in
+      # tests. The class name of the gateway is used to generate the
+      # folder name for the VCR cassettes used within this test.
       def gateway
         Gateway.new
       end
 
+      # Use the class name of the gateway to generate a directory in
+      # `test/vcr_cassettes` where all cassettes for the custom gateway
+      # will go. This doesn't need to be overridden unless you need to
+      # customize the gateway cassette directory name.
+      #
+      # @return [String]
+      def gateway_cassette_name
+        gateway.class.name.systemize
+      end
+
       def test_authorize
-        response = gateway.authorize(200, tender)
+        VCR.use_cassette "#{gateway_cassette_name}/authorize" do
+          response = gateway.authorize(200, tender)
 
-        assert(response.success?)
-        assert(response.message.present?)
+          assert(response.success?)
+          assert(response.message.present?)
 
-        gift_card.reload
-        assert_equal(8.to_m, gift_card.balance)
-        assert_equal(2.to_m, gift_card.used)
+          gift_card.reload
+          assert_equal(8.to_m, gift_card.balance)
+          assert_equal(2.to_m, gift_card.used)
+        end
       end
 
       def test_cancel
-        response = gateway.authorize(200, tender)
-        assert(response.success?)
+        VCR.use_cassette "#{gateway_cassette_name}/cancel" do
+          response = gateway.authorize(200, tender)
+          assert(response.success?)
 
-        response = gateway.cancel(200, tender)
+          response = gateway.cancel(200, tender)
 
-        assert(response.success?)
-        assert(response.message.present?)
+          assert(response.success?)
+          assert(response.message.present?)
 
-        gift_card.reload
-        assert_equal(10.to_m, gift_card.balance)
-        assert_equal(0.to_m, gift_card.used)
+          gift_card.reload
+          assert_equal(10.to_m, gift_card.balance)
+          assert_equal(0.to_m, gift_card.used)
+        end
       end
 
       def test_capture
-        assert(gateway.capture(200, tender).success?)
-        assert_equal(10.to_m, gift_card.reload.balance)
+        VCR.use_cassette "#{gateway_cassette_name}/capture" do
+          assert(gateway.capture(200, tender).success?)
+          assert_equal(10.to_m, gift_card.reload.balance)
+        end
       end
 
       def test_purchase
-        response = gateway.purchase(200, tender)
+        VCR.use_cassette "#{gateway_cassette_name}/purchase" do
+          response = gateway.purchase(200, tender)
 
-        assert(response.success?)
-        assert(response.message.present?)
+          assert(response.success?)
+          assert(response.message.present?)
 
-        gift_card.reload
-        assert_equal(8.to_m, gift_card.balance)
-        assert_equal(2.to_m, gift_card.used)
+          gift_card.reload
+          assert_equal(8.to_m, gift_card.balance)
+          assert_equal(2.to_m, gift_card.used)
+        end
       end
 
       def test_refund
-        response = gateway.authorize(200, tender)
-        assert(response.success?)
+        VCR.use_cassette "#{gateway_cassette_name}/refund" do
+          response = gateway.authorize(200, tender)
+          assert(response.success?)
 
-        response = gateway.refund(200, tender)
+          response = gateway.refund(200, tender)
 
-        assert(response.success?)
-        assert(response.message.present?)
+          assert(response.success?)
+          assert(response.message.present?)
 
-        gift_card.reload
-        assert_equal(10.to_m, gift_card.balance)
-        assert_equal(0.to_m, gift_card.used)
+          gift_card.reload
+          assert_equal(10.to_m, gift_card.balance)
+          assert_equal(0.to_m, gift_card.used)
+        end
       end
 
       def test_balance
-        balance = gateway.balance(gift_card.number)
-        assert_equal(10.to_m, balance)
+        VCR.use_cassette "#{gateway_cassette_name}/balance" do
+          balance = gateway.balance(gift_card.number)
+          assert_equal(10.to_m, balance)
 
-        gateway.authorize(300, tender)
+          gateway.authorize(300, tender)
 
-        balance = gateway.balance(gift_card.number)
-        assert_equal(7.to_m, balance)
+          balance = gateway.balance(gift_card.number)
+          assert_equal(7.to_m, balance)
+        end
       end
 
       def test_lookup
-        lookup = gateway.lookup(email: gift_card.to, token: gift_card.token)
-        assert_equal(gift_card.id, lookup.id)
+        VCR.use_cassette "#{gateway_cassette_name}/lookup" do
+          lookup = gateway.lookup(email: gift_card.to, token: gift_card.token)
+          assert_equal(gift_card.id, lookup.id)
 
-        lookup = gateway.lookup(email: 'foo', token: gift_card.token)
-        assert_nil(lookup)
+          lookup = gateway.lookup(email: 'foo', token: gift_card.token)
+          assert_nil(lookup)
+        end
       end
     end
   end


### PR DESCRIPTION
If you're creating a new custom gift card gateway for your project, and you want to use the tests from base as a starting point for that integration, you currently must duplicate the tests from the plugin in your own plugin, which makes things a bit harder but also removes the ability to take on updates to the test in case of bug fixes. To improve this experience, the `Workarea::GiftCards::GatewayTest` has been modified to more easily allow decorating it in a host application. All tests are now wrapped in a VCR cassette whose name is defined by the parameterized gateway class name and the name of the method being tested. This will activate and create cassettes in the real world when a gateway makes an outbound HTTP call, similar to `CreditCardIntegrationTest`.

For example, a baseline gateway test implementation could look something like:

```ruby
module Workarea
  module GiftCards
    decorate GatewayTest do
      # Provide a custom object to grab gift card information
      def gift_card
        CustomGiftCard.new
      end

      # Provide the custom Gift Card implementation
      def gateway
        CustomGiftCardGateway.new(Workarea.config.custom_gift_card_test_credentials)
      end
    end
  end
end
```