### PR TITLE
Fix Update Step Result

### DIFF
--- a/app/models/workarea/checkout/steps/gift_card.rb
+++ b/app/models/workarea/checkout/steps/gift_card.rb
@@ -12,8 +12,9 @@ module Workarea
         #
         def update(params = {})
           gift_card_params = extract_gift_card_params(params)
-          return false unless applicable_gift_card?(gift_card_params)
-          return false unless add_gift_card(gift_card_params)
+
+          add_gift_card(gift_card_params) if applicable_gift_card?(gift_card_params)
+
           update_order
         end
 


### PR DESCRIPTION
The result of `Checkout::Steps::GiftCards#update` does not comply with the protocol set out by `Checkout#update` in that it returns `false` when nothing can be done. This has been changed to pass through when no Gift Card params are sent into the update.