### PR TITLE
Ruby 3.x compatibility: replace deprecated APIs, update gemspec ruby constraint

### DIFF
--- a/app/controllers/workarea/admin/payment_gift_cards_controller.rb
+++ b/app/controllers/workarea/admin/payment_gift_cards_controller.rb
@@ -25,7 +25,7 @@ module Workarea
       def edit; end
 
       def update
-        if @gift_card.update_attributes(gift_card_params)
+        if @gift_card.update(gift_card_params)
           flash[:success] = 'Gift card has been saved.'
           redirect_to payment_gift_card_path(@gift_card)
         else

--- a/app/controllers/workarea/api/admin/gift_cards_controller.rb
+++ b/app/controllers/workarea/api/admin/gift_cards_controller.rb
@@ -250,7 +250,7 @@ module Workarea
           end
 
           def update
-            @gift_card.update_attributes!(params[:gift_card])
+            @gift_card.update!(params[:gift_card])
             respond_with gift_card: @gift_card
           end
 

--- a/workarea-gift_cards.gemspec
+++ b/workarea-gift_cards.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.license = 'Business Software License'
 
-  s.required_ruby_version = '>= 2.3.0'
+  s.required_ruby_version = '>= 2.7', '< 3.5'
 
   s.add_dependency 'workarea', '~> 3.x', '>= 3.5.x'
 end


### PR DESCRIPTION
## Ruby 3.x Compatibility

### Changes
- Replace `update_attributes`/`update_attributes!` with `update`/`update!` (removed in Rails 6.1+)
- Add `required_ruby_version = '>= 2.7', '< 3.5'` to gemspec

### Verification
```sh
grep -rn 'update_attributes\|Dir\.exists?\|URI\.escape' --include='*.rb' . | grep -v vendor
# Returns no output
```

### Related
Closes workarea-commerce/workarea#676

Client impact: None — backward compatible